### PR TITLE
fix: Fallback to 'N/A' text when no inputs avaliable in getDialogueName

### DIFF
--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -423,6 +423,7 @@ class Controls extends FlxActionSet
 
   public function getDialogueName(action:FlxActionDigital, ?ignoreSurrounding:Bool = false):String
   {
+    if (action.inputs.length == 0) return 'N/A';
     var input = action.inputs[0];
     if (ignoreSurrounding == false)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

## Briefly describe the issue(s) fixed.

## Include any relevant screenshots or videos.
