### PR TITLE
fix: Chart loading fixes

### DIFF
--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -192,12 +192,13 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata>
     }
   }
 
-  public function parseEntryMetadataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version):Null<SongMetadata>
+  public function parseEntryMetadataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version,
+      ?variation:String):Null<SongMetadata>
   {
     // If a version rule is not specified, do not check against it.
     if (SONG_METADATA_VERSION_RULE == null || VersionUtil.validateVersion(version, SONG_METADATA_VERSION_RULE))
     {
-      return parseEntryMetadataRaw(contents, fileName);
+      return parseEntryMetadataRaw(contents, fileName, variation);
     }
     else if (VersionUtil.validateVersion(version, "2.1.x"))
     {
@@ -404,12 +405,13 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata>
     }
   }
 
-  public function parseEntryChartDataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version):Null<SongChartData>
+  public function parseEntryChartDataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version,
+      ?variation:String):Null<SongChartData>
   {
     // If a version rule is not specified, do not check against it.
     if (SONG_CHART_DATA_VERSION_RULE == null || VersionUtil.validateVersion(version, SONG_CHART_DATA_VERSION_RULE))
     {
-      return parseEntryChartDataRaw(contents, fileName);
+      return parseEntryChartDataRaw(contents, fileName, variation);
     }
     else
     {

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -1234,6 +1234,23 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var songMetadata:Map<String, SongMetadata> = [];
 
   /**
+   * Updates the current song's play data variations list.
+   */
+  function refreshPlayDataVariations():Void
+  {
+    var songVariations:Array<String> = songMetadata.get(Constants.DEFAULT_VARIATION).playData.songVariations;
+    songVariations.clear();
+    for (variation in availableVariations)
+    {
+      if (variation == Constants.DEFAULT_VARIATION) continue;
+      if (!songVariations.contains(variation))
+      {
+        songVariations.push(variation);
+      }
+    }
+  }
+
+  /**
    * Retrieves the list of variations for the current song.
    */
   var availableVariations(get, never):Array<String>;
@@ -5974,7 +5991,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     if (songMetadata.size() > 1)
     {
-      if (variationMetadata.playData.difficulties.length == 0)
+      if (variation != Constants.DEFAULT_VARIATION && variationMetadata.playData.difficulties.length == 0)
       {
         songMetadata.remove(variation);
         songChartData.remove(variation);
@@ -5991,6 +6008,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (selectedDifficulty == difficulty
       || !variationMetadata.playData.difficulties.contains(selectedDifficulty)) selectedDifficulty = variationMetadata.playData.difficulties[0];
 
+    refreshPlayDataVariations();
     difficultySelectDirty = true; // Force the Difficulty toolbox to update.
   }
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -1218,6 +1218,7 @@ class ChartEditorDialogHandler
       pendingVariation.timeChanges[0].bpm = dialogBPM.value;
 
       state.songMetadata.set(pendingVariation.variation, pendingVariation);
+      state.refreshPlayDataVariations();
       state.difficultySelectDirty = true; // Force the Difficulty toolbox to update.
 
       // Don't update conductor since we haven't switched to the new variation yet.

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -227,7 +227,8 @@ class ChartEditorImportExportHandler
       var variMetadataVersion:Null<thx.semver.Version> = VersionUtil.getVersionFromJSON(variMetadataString);
       if (variMetadataVersion == null) throw 'Could not read metadata ($variation) version.';
 
-      var variMetadata:Null<SongMetadata> = SongRegistry.instance.parseEntryMetadataRawWithMigration(baseMetadataString, variMetadataPath, variMetadataVersion);
+      var variMetadata:Null<SongMetadata> = SongRegistry.instance.parseEntryMetadataRawWithMigration(variMetadataString, variMetadataPath,
+        variMetadataVersion, variation);
       if (variMetadata == null) throw 'Could not read metadata ($variation).';
       songMetadatas.set(variation, variMetadata);
 
@@ -238,7 +239,7 @@ class ChartEditorImportExportHandler
       if (variChartDataVersion == null) throw 'Could not read chart data version ($variation).';
 
       var variChartData:Null<SongChartData> = SongRegistry.instance.parseEntryChartDataRawWithMigration(variChartDataString, variChartDataPath,
-        variChartDataVersion);
+        variChartDataVersion, variation);
       if (variChartData == null) throw 'Could not read chart data ($variation).';
       songChartDatas.set(variation, variChartData);
     }


### PR DESCRIPTION
* Prevents charter from deleting `default` variation when there's more than one variation available.
* Fixes song variation list not being saved into `default` metadata file.
* Fixes loading from FNFC incorrectly loading all variations as `default`.
* Fixes loading from FNFC incorrectly using the `default` variation metadata for every other variation.

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

## Briefly describe the issue(s) fixed.

## Include any relevant screenshots or videos.
